### PR TITLE
npmの組織管理用にプロジェクト名を変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tatami",
+  "name": "@notainc/tatami",
   "version": "1.0.0",
   "description": "Tatami is Nota's fork of Bootstrap 3. Specialized modern web app UI. Support touch and mouse inputs.",
   "main": "assets/javascripts/bootstrap.js",


### PR DESCRIPTION
## 概要
- npmのorganization（組織名notainc）でパッケージを管理するために、プロジェクト名を変更します。
- プロジェクト名の変更だけなので、テストに通ったらマージします。