### PR TITLE
Tatami type

### DIFF
--- a/assets/stylesheets/bootstrap/_type.scss
+++ b/assets/stylesheets/bootstrap/_type.scss
@@ -10,7 +10,6 @@ h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: $headings-font-family;
   font-weight: $headings-font-weight;
-  line-height: $headings-line-height;
   color: $headings-color;
 
   small,
@@ -24,8 +23,9 @@ h1, h2, h3, h4, h5, h6,
 h1, .h1,
 h2, .h2,
 h3, .h3 {
+  line-height: $headings-line-height;
   margin-top: $line-height-computed;
-  margin-bottom: ($line-height-computed / 2);
+  margin-bottom: ($line-height-computed / 1.5);
 
   small,
   .small {
@@ -35,8 +35,9 @@ h3, .h3 {
 h4, .h4,
 h5, .h5,
 h6, .h6 {
-  margin-top: ($line-height-computed / 2);
-  margin-bottom: ($line-height-computed / 2);
+  line-height: $line-height-computed;
+  margin-top: ($line-height-computed / 1.5);
+  margin-bottom: ($line-height-computed / 1.5);
 
   small,
   .small {
@@ -56,7 +57,7 @@ h6, .h6 { font-size: $font-size-h6; }
 // -------------------------
 
 p {
-  margin: 0 0 ($line-height-computed / 2);
+  margin: 0 0 ($line-height-computed / 1.5);
 }
 
 .lead {

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -53,22 +53,22 @@ $font-size-base:          14px !default;
 $font-size-large:         16px !default;
 $font-size-small:         ceil(($font-size-base * 0.85)) !default; // ~12px
 
-$font-size-h1:            floor(($font-size-base * 2.86)) !default; // ~40px
-$font-size-h2:            floor(($font-size-base * 2.29)) !default; // ~32px
-$font-size-h3:            ceil(($font-size-base * 1.7)) !default; // ~24px
+$font-size-h1:            floor(($font-size-base * 2.5)) !default; // ~35px
+$font-size-h2:            floor(($font-size-base * 2)) !default; // ~28px
+$font-size-h3:            ceil(($font-size-base * 1.5)) !default; // ~21px
 $font-size-h4:            ceil(($font-size-base * 1.14)) !default; // ~16px
 $font-size-h5:            $font-size-base !default;
 $font-size-h6:            ceil(($font-size-base * 0.85)) !default; // ~12px
 
 //** Unit-less `line-height` for use in components like buttons.
-$line-height-base:        1.71428572 !default; // 24/14
+$line-height-base:        1.71429 !default; // 24/14
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
 $line-height-computed:    floor(($font-size-base * $line-height-base)) !default; // ~24px
 
 //** By default, this inherits from the `<body>`.
 $headings-font-family:    inherit !default;
 $headings-font-weight:    500 !default;
-$headings-line-height:    1.25 !default;
+$headings-line-height:    1.14286 !default;
 $headings-color:          inherit !default;
 
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -68,7 +68,7 @@ $line-height-computed:    floor(($font-size-base * $line-height-base)) !default;
 //** By default, this inherits from the `<body>`.
 $headings-font-family:    inherit !default;
 $headings-font-weight:    500 !default;
-$headings-line-height:    1.14286 !default;
+$headings-line-height:    1.14286 !default; // 8/7
 $headings-color:          inherit !default;
 
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -220,7 +220,7 @@ $input-height-small:             (floor($font-size-small * $line-height-small) +
 //** `.form-group` margin
 $form-group-margin-bottom:       15px !default;
 
-$legend-color:                   $gray-dark !default;
+$legend-color:                   $text-color !default;
 $legend-border-color:            #e5e5e5 !default;
 
 //** Background color for textual input addons
@@ -244,9 +244,9 @@ $dropdown-border:                rgba(0,0,0,.15) !default;
 $dropdown-divider-bg:            #e5e5e5 !default;
 
 //** Dropdown link text color.
-$dropdown-link-color:            $gray-dark !default;
+$dropdown-link-color:            $text-color !default;
 //** Hover color for dropdown links.
-$dropdown-link-hover-color:      darken($gray-dark, 5%) !default;
+$dropdown-link-hover-color:      darken($text-color, 5%) !default;
 //** Hover background for dropdown links.
 $dropdown-link-hover-bg:         #f5f5f5 !default;
 
@@ -711,7 +711,7 @@ $panel-border-radius:         $border-radius-base !default;
 $panel-inner-border:          #ddd !default;
 $panel-footer-bg:             #f5f5f5 !default;
 
-$panel-default-text:          $gray-dark !default;
+$panel-default-text:          $text-color !default;
 $panel-default-border:        #ddd !default;
 $panel-default-heading-bg:    #f5f5f5 !default;
 
@@ -835,7 +835,7 @@ $kbd-color:                   #fff !default;
 $kbd-bg:                      #333 !default;
 
 $pre-bg:                      #f5f5f5 !default;
-$pre-color:                   $gray-dark !default;
+$pre-color:                   $text-color !default;
 $pre-border-color:            #ccc !default;
 $pre-scrollable-max-height:   340px !default;
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -68,7 +68,7 @@ $line-height-computed:    floor(($font-size-base * $line-height-base)) !default;
 //** By default, this inherits from the `<body>`.
 $headings-font-family:    inherit !default;
 $headings-font-weight:    500 !default;
-$headings-line-height:    1.5 !default;
+$headings-line-height:    1.25 !default;
 $headings-color:          inherit !default;
 
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -29,7 +29,7 @@ $brand-danger:          #F85C5F !default;
 //** Background color for `<body>`.
 $body-bg:               #eee !default;
 //** Global text color on `<body>`.
-$text-color:            $gray-dark !default;
+$text-color:            lighten($gray-base, 25%) !default;
 
 //** Global textual link color.
 $link-color:            $brand-primary !default;
@@ -53,22 +53,22 @@ $font-size-base:          14px !default;
 $font-size-large:         16px !default;
 $font-size-small:         ceil(($font-size-base * 0.85)) !default; // ~12px
 
-$font-size-h1:            floor(($font-size-base * 2.6)) !default; // ~36px
-$font-size-h2:            floor(($font-size-base * 2.15)) !default; // ~30px
+$font-size-h1:            floor(($font-size-base * 2.86)) !default; // ~40px
+$font-size-h2:            floor(($font-size-base * 2.29)) !default; // ~32px
 $font-size-h3:            ceil(($font-size-base * 1.7)) !default; // ~24px
-$font-size-h4:            ceil(($font-size-base * 1.25)) !default; // ~18px
+$font-size-h4:            ceil(($font-size-base * 1.14)) !default; // ~16px
 $font-size-h5:            $font-size-base !default;
 $font-size-h6:            ceil(($font-size-base * 0.85)) !default; // ~12px
 
 //** Unit-less `line-height` for use in components like buttons.
-$line-height-base:        1.71428571 !default; // 24/14
+$line-height-base:        1.71428572 !default; // 24/14
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-$line-height-computed:    round(($font-size-base * $line-height-base)) !default; // ~20px
+$line-height-computed:    floor(($font-size-base * $line-height-base)) !default; // ~24px
 
 //** By default, this inherits from the `<body>`.
 $headings-font-family:    inherit !default;
 $headings-font-weight:    500 !default;
-$headings-line-height:    1.1 !default;
+$headings-line-height:    1.5 !default;
 $headings-color:          inherit !default;
 
 

--- a/demo/tatami/src/client/css/app.scss
+++ b/demo/tatami/src/client/css/app.scss
@@ -10,10 +10,6 @@ body {
   margin-bottom: 500px;
 }
 
-h1 {
-  color: black;
-}
-
 .single-buttons {
   .btn {
     min-width: 100px;

--- a/demo/tatami/src/client/js/components/type.js
+++ b/demo/tatami/src/client/js/components/type.js
@@ -3,18 +3,28 @@ import React from 'react'
 export default function Type () {
   return (
     <div>
-      <h1>h1. Bootstrap heading</h1>
-      <h2>h2. Bootstrap heading</h2>
-      <h3>h3. Bootstrap heading</h3>
-      <h4>h4. Bootstrap heading</h4>
+      <h1><strong>h1. Far far away, behind the word mountains</strong></h1>
+      <h1>h1. Far far away, behind the word mountains</h1>
+      <h2><strong>h2. Far far away, behind the word mountains</strong></h2>
+      <h2>h2. Far far away, behind the word mountains</h2>
+      <h3><strong>h3. Far far away, behind the word mountains</strong></h3>
+      <h3>h3. Far far away, behind the word mountains</h3>
+      <h4><strong>h4. Far far away, behind the word mountains</strong></h4>
+      <h4>h4. Far far away, behind the word mountains</h4>
       <p>Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam id dolor id nibh ultricies vehicula.</p>
       <p>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec ullamcorper nulla non metus auctor fringilla. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla.</p>
       <p>Maecenas sed diam eget risus varius blandit sit amet non magna. Donec id elit non mi porta gravida at eget metus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</p>
+      <h5><strong>h5. Far far away, behind the word mountains</strong></h5>
+      <h5>h5. Far far away, behind the word mountains</h5>
+      <h6><strong>h6. Far far away, behind the word mountains</strong></h6>
+      <h6>h6. Far far away, behind the word mountains</h6>
+      <small><strong>Small text</strong></small><br />
+      <small>Small text</small>
+
       <div>
         <p><a href='javascript:;'>Here is a text link</a></p>
         <p><button className='btn btn-link'>Button link</button></p>
       </div>
-
 
       <br />
       <br />


### PR DESCRIPTION
body文字色、ヘディング系の文字サイズと改行幅を調整しました。

改行幅については、1.5固定にしました。
スタイルガイドでみるとh3だけが、このルールに沿っていないので変更した部分になります。

色
$text-colorを#333から、#404040 に変更
dropdown内文字色、legend文字色、panel内文字色もこれにあわせる（これまでも#333で同じだったが、dark-grayが指定されていた）

### 相談事項

h3のline-heightは、1.5ルールにそって、36pxになりますが、よいですかね？ Styleguideをこれにあわせておいてもらえるとよいかも。

TINYはbootsrapのSmallに対応させると、文字サイズが10px -> 12pxになります。ここもこれでよいですかね？
サンプルではどこかで使ってますか？

[![Screenshot from Gyazo](https://gyazo.com/465b029782491161f49eb88c9cb155b1/raw)](https://gyazo.com/465b029782491161f49eb88c9cb155b1)
ここでは、12pxなんで、`<Small>` を使えばよさそう


body 2クラスが用意できていないですが、ボタンやformの各種largeサイズの基本フォントサイズは16pxになっています。$font-size-large で定義されています。
よってクラスの追加などは、後々できるでしょう。当面は、必要な箇所で、 $font-size-large を使うとよいです。
styleguideを見ていると、モバイルUIの本文はほぼ14pxですね...本文で16pxを使う場所はすくなさそう。


captionはh6で読み替えれば大丈夫そうですね。



[![Screenshot from Gyazo](https://gyazo.com/0de6c50169955fb5c047edc560c8d896/raw)](https://gyazo.com/0de6c50169955fb5c047edc560c8d896)