### PR TITLE
Tatami alert

### DIFF
--- a/assets/stylesheets/bootstrap/_alerts.scss
+++ b/assets/stylesheets/bootstrap/_alerts.scss
@@ -18,9 +18,6 @@
 
     > button {
       margin-top: 12px;
-    }
-
-    > button + button {
       margin-left: 0;
     }
   }
@@ -55,9 +52,6 @@
   > button {
     align-self: center;
     flex-shrink: 0;
-  }
-
-  > button + button {
     margin-left: 12px;
   }
 

--- a/assets/stylesheets/bootstrap/_alerts.scss
+++ b/assets/stylesheets/bootstrap/_alerts.scss
@@ -11,9 +11,27 @@
   margin-bottom: $line-height-computed;
   border: 1px solid transparent;
   border-radius: $alert-border-radius;
+  display: flex;
+
+  &.alert-vertical {
+    flex-direction: column;
+
+    > button {
+      margin-top: 12px;
+    }
+
+    > button + button {
+      margin-left: 0;
+    }
+  }
+
+  .alert-body {
+    flex-grow: 1;
+    padding: $alert-body-padding;
+  }
 
   // Headings for larger alerts
-  h4 {
+  h1, h2, h3, h4, h5, h6 {
     margin-top: 0;
     // Specified for the h4 to prevent conflicts of changing $headings-color
     color: inherit;
@@ -34,26 +52,35 @@
     margin-top: 5px;
   }
 
+  > button {
+    align-self: center;
+    flex-shrink: 0;
+  }
+
+  > button + button {
+    margin-left: 12px;
+  }
+
   // Adjust close link position
   .close {
-    position: relative;
-    top: -2px;
-    right: -21px;
-    color: inherit;
+    margin-left: 12px;
   }
 }
 
 // Dismissible alerts
 //
-// Expand the right padding and account for the close button's positioning.
+// We have removed this class, and switched to flexbox
 
 .alert-dismissible {
-  padding-right: ($alert-padding + 20);
 }
 
 // Alternate styles
 //
 // Generate contextual modifier classes for colorizing the alert.
+
+.alert-default {
+  @include alert-variant($alert-default-bg, $alert-default-border, $alert-default-text);
+}
 
 .alert-success {
   @include alert-variant($alert-success-bg, $alert-success-border, $alert-success-text);

--- a/assets/stylesheets/bootstrap/_close.scss
+++ b/assets/stylesheets/bootstrap/_close.scss
@@ -6,22 +6,28 @@
 .close {
   display: block;
   float: right;
-  font-size: ($font-size-base * 1.5);
+  font-size: 28px;
   font-weight: $close-font-weight;
   line-height: 1;
   color: $close-color;
   text-shadow: $close-text-shadow;
-  width: 21px;
-  height: 21px;
+  width: 28px;
+  height: 28px;
   order: 2;
-  @include opacity(.2);
+
+  span {
+    opacity: .3;
+  }
 
   [data-hover-visible] &:hover,
   [data-focus-visible] &:focus {
     color: $close-color;
     text-decoration: none;
     cursor: pointer;
-    @include opacity(.5);
+
+    span {
+      opacity: .5;
+    }
   }
 
   [data-focus-visible] &:focus {
@@ -38,5 +44,6 @@ button.close {
   cursor: pointer;
   background: transparent;
   border: 0;
+  border-radius: $btn-border-radius-base;
   -webkit-appearance: none;
 }

--- a/assets/stylesheets/bootstrap/_modals.scss
+++ b/assets/stylesheets/bootstrap/_modals.scss
@@ -84,7 +84,9 @@
   .close {
     order: 2;
     margin-left: 8px;
-    margin-top: 2px;
+    margin-top: -2px;
+    margin-right: -2px;
+    flex-shrink: 0;
   }
 }
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -499,21 +499,25 @@ $jumbotron-heading-font-size:    ceil(($font-size-base * 4.5)) !default;
 //
 //## Define colors for form feedback states and, by default, alerts.
 
+$state-default-text:             $text-color !default;
+$state-default-bg:               #fff !default;
+$state-default-border:           lighten($gray-base, 85%) !default;
+
 $state-success-text:             darken($brand-success, 10%) !default;
 $state-success-bg:               lighten($brand-success, 35%) !default;
-$state-success-border:           darken($brand-success, 10%) !default;
+$state-success-border:           darken(desaturate($state-success-bg, 30%), 5%) !default;
 
-$state-info-text:                darken($brand-info, 10%) !default;
-$state-info-bg:                  lighten($brand-info, 35%) !default;
-$state-info-border:              darken($brand-info, 10%) !default;
+$state-info-text:                darken($brand-primary, 10%) !default;
+$state-info-bg:                  lighten($brand-primary, 35%) !default;
+$state-info-border:              darken(desaturate($state-info-bg, 30%), 5%) !default;
 
-$state-warning-text:             darken($brand-warning, 15%) !default;
-$state-warning-bg:               lighten($brand-warning, 20%) !default;
-$state-warning-border:           darken($brand-warning, 15%) !default;
+$state-warning-text:             darken($brand-warning, 20%) !default;
+$state-warning-bg:               lighten($brand-warning, 15%) !default;
+$state-warning-border:           darken(desaturate($state-warning-bg, 30%), 3%) !default;
 
 $state-danger-text:              darken($brand-danger, 10%) !default;
-$state-danger-bg:                lighten($brand-danger, 20%) !default;
-$state-danger-border:            darken($brand-danger, 10%) !default;
+$state-danger-bg:                lighten($brand-danger, 25%) !default;
+$state-danger-border:            darken(desaturate($state-danger-bg, 30%), 5%) !default;
 
 //== Tooltips
 //
@@ -624,24 +628,24 @@ $alert-border-radius:         4px !default;
 $alert-link-font-weight:      bold !default;
 
 $alert-default-text:          $text-color !default;
-$alert-default-bg:            #fff !default;
-$alert-default-border:        lighten($gray-base, 85%) !default;
+$alert-default-bg:            $state-default-bg !default;
+$alert-default-border:        $state-default-border !default;
 
 $alert-success-text:          $text-color !default;
-$alert-success-bg:            lighten($brand-success, 35%) !default;
-$alert-success-border:        darken(desaturate($alert-success-bg, 30%), 5%) !default;
+$alert-success-bg:            $state-success-bg !default;
+$alert-success-border:        $state-success-border !default;
 
 $alert-info-text:             $text-color !default;
-$alert-info-bg:               lighten($brand-primary, 35%)  !default;
-$alert-info-border:           darken(desaturate($alert-info-bg, 30%), 5%) !default;
+$alert-info-bg:               $state-info-bg  !default;
+$alert-info-border:           $state-info-border !default;
 
 $alert-warning-text:          $text-color !default;
-$alert-warning-bg:            lighten($brand-warning, 15%) !default;
-$alert-warning-border:        darken(desaturate($alert-warning-bg, 30%), 3%) !default;
+$alert-warning-bg:            $state-warning-bg !default;
+$alert-warning-border:        $state-warning-border !default;
 
 $alert-danger-text:           $text-color !default;
-$alert-danger-bg:             lighten($brand-danger, 25%) !default;
-$alert-danger-border:         darken(desaturate($alert-danger-bg, 30%), 5%) !default;
+$alert-danger-bg:             $state-danger-bg !default;
+$alert-danger-border:         $state-danger-border !default;
 
 //== Progress bars
 //
@@ -723,19 +727,19 @@ $panel-primary-border:        $brand-primary !default;
 $panel-primary-heading-bg:    $brand-primary !default;
 
 $panel-success-text:          $state-success-text !default;
-$panel-success-border:        $state-success-border !default;
+$panel-success-border:        $state-success-text !default;
 $panel-success-heading-bg:    $state-success-bg !default;
 
 $panel-info-text:             $state-info-text !default;
-$panel-info-border:           $state-info-border !default;
+$panel-info-border:           $state-info-text !default;
 $panel-info-heading-bg:       $state-info-bg !default;
 
 $panel-warning-text:          $state-warning-text !default;
-$panel-warning-border:        $state-warning-border !default;
+$panel-warning-border:        $state-warning-text !default;
 $panel-warning-heading-bg:    $state-warning-bg !default;
 
 $panel-danger-text:           $state-danger-text !default;
-$panel-danger-border:         $state-danger-border !default;
+$panel-danger-border:         $state-danger-text !default;
 $panel-danger-heading-bg:     $state-danger-bg !default;
 
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -499,22 +499,21 @@ $jumbotron-heading-font-size:    ceil(($font-size-base * 4.5)) !default;
 //
 //## Define colors for form feedback states and, by default, alerts.
 
-$state-success-text:             #3c763d !default;
-$state-success-bg:               #dff0d8 !default;
-$state-success-border:           darken(adjust-hue($state-success-bg, -10), 5%) !default;
+$state-success-text:             darken($brand-success, 10%) !default;
+$state-success-bg:               lighten($brand-success, 35%) !default;
+$state-success-border:           darken($brand-success, 10%) !default;
 
-$state-info-text:                #31708f !default;
-$state-info-bg:                  #d9edf7 !default;
-$state-info-border:              darken(adjust-hue($state-info-bg, -10), 7%) !default;
+$state-info-text:                darken($brand-info, 10%) !default;
+$state-info-bg:                  lighten($brand-info, 35%) !default;
+$state-info-border:              darken($brand-info, 10%) !default;
 
-$state-warning-text:             #8a6d3b !default;
-$state-warning-bg:               #fcf8e3 !default;
-$state-warning-border:           darken(adjust-hue($state-warning-bg, -10), 5%) !default;
+$state-warning-text:             darken($brand-warning, 15%) !default;
+$state-warning-bg:               lighten($brand-warning, 20%) !default;
+$state-warning-border:           darken($brand-warning, 15%) !default;
 
-$state-danger-text:              #a94442 !default;
-$state-danger-bg:                #f2dede !default;
-$state-danger-border:            darken(adjust-hue($state-danger-bg, -10), 5%) !default;
-
+$state-danger-text:              darken($brand-danger, 10%) !default;
+$state-danger-bg:                lighten($brand-danger, 20%) !default;
+$state-danger-border:            darken($brand-danger, 10%) !default;
 
 //== Tooltips
 //
@@ -619,26 +618,30 @@ $modal-sm:                    300px !default;
 //
 //## Define alert colors, border radius, and padding.
 
-$alert-padding:               15px !default;
-$alert-border-radius:         $border-radius-base !default;
+$alert-padding:               ((56px - $input-height-base - 2px) / 2) !default;
+$alert-body-padding:          (($input-height-base - $line-height-computed) / 2) 8px !default;
+$alert-border-radius:         4px !default;
 $alert-link-font-weight:      bold !default;
 
-$alert-success-bg:            $state-success-bg !default;
-$alert-success-text:          $state-success-text !default;
-$alert-success-border:        $state-success-border !default;
+$alert-default-text:          $text-color !default;
+$alert-default-bg:            #fff !default;
+$alert-default-border:        lighten($gray-base, 85%) !default;
 
-$alert-info-bg:               $state-info-bg !default;
-$alert-info-text:             $state-info-text !default;
-$alert-info-border:           $state-info-border !default;
+$alert-success-text:          $text-color !default;
+$alert-success-bg:            lighten($brand-success, 35%) !default;
+$alert-success-border:        darken(desaturate($alert-success-bg, 30%), 5%) !default;
 
-$alert-warning-bg:            $state-warning-bg !default;
-$alert-warning-text:          $state-warning-text !default;
-$alert-warning-border:        $state-warning-border !default;
+$alert-info-text:             $text-color !default;
+$alert-info-bg:               lighten($brand-primary, 35%)  !default;
+$alert-info-border:           darken(desaturate($alert-info-bg, 30%), 5%) !default;
 
-$alert-danger-bg:             $state-danger-bg !default;
-$alert-danger-text:           $state-danger-text !default;
-$alert-danger-border:         $state-danger-border !default;
+$alert-warning-text:          $text-color !default;
+$alert-warning-bg:            lighten($brand-warning, 15%) !default;
+$alert-warning-border:        darken(desaturate($alert-warning-bg, 30%), 3%) !default;
 
+$alert-danger-text:           $text-color !default;
+$alert-danger-bg:             lighten($brand-danger, 25%) !default;
+$alert-danger-border:         darken(desaturate($alert-danger-bg, 30%), 5%) !default;
 
 //== Progress bars
 //
@@ -819,9 +822,9 @@ $carousel-caption-color:                      #fff !default;
 //
 //##
 
-$close-font-weight:           bold !default;
+$close-font-weight:           normal !default;
 $close-color:                 #000 !default;
-$close-text-shadow:           0 1px 0 #fff !default;
+$close-text-shadow:           none !default;
 
 
 //== Code

--- a/assets/stylesheets/bootstrap/mixins/_alerts.scss
+++ b/assets/stylesheets/bootstrap/mixins/_alerts.scss
@@ -8,7 +8,22 @@
   hr {
     border-top-color: darken($border, 5%);
   }
+
+  @if $background != #fff {
+    button {
+      &,
+      [data-hover-visible] &:hover,
+      [data-hover-visible] &:hover:active,
+      &:active {
+        border-color: transparent;
+      }
+    }
+  }
+
   .alert-link {
-    color: darken($text-color, 10%);
+    &,
+    [data-hover-visible] &:hover {
+      color: $text-color;
+    }
   }
 }

--- a/demo/tatami/default.html
+++ b/demo/tatami/default.html
@@ -6,7 +6,6 @@
   <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" />
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,500,600,700" rel="stylesheet" />
   <link rel="icon" href="./public/assets/img/favicon/favicon.ico" />
-  <link rel="manifest" href="/manifest.json" />
   <link rel="apple-touch-icon" sizes="180x180" href="./public/assets/img/favicon/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="SW Skelton" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/demo/tatami/index.html
+++ b/demo/tatami/index.html
@@ -6,7 +6,6 @@
   <link rel="stylesheet" type="text/css" href="./public/assets/css/app.css" />
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,500,600,700" rel="stylesheet" />
   <link rel="icon" href="./public/assets/img/favicon/favicon.ico" />
-  <link rel="manifest" href="/manifest.json" />
   <link rel="apple-touch-icon" sizes="180x180" href="./public/assets/img/favicon/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="SW Skelton" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/demo/tatami/src/client/js/components/alerts.js
+++ b/demo/tatami/src/client/js/components/alerts.js
@@ -3,7 +3,7 @@ import React from 'react'
 export default function Alerts () {
   return (
     <div>
-      <h2>Alerts</h2>
+      <h1>Alerts</h1>
       <div className='alert alert-default' role='alert'>
         <div className='alert-body'>
           Default. This is sample text.
@@ -55,6 +55,61 @@ export default function Alerts () {
         </button>
       </div>
 
+
+      <h3>Small size</h3>
+      <div className='row'>
+        <div className='col-md-4'>
+          <div className='alert alert-default alert-vertical' role='alert'>
+            <div className='alert-body'>
+              Default. This is sample text.
+              {' '}
+            </div>
+            <button type='button' className='btn btn-default btn-lg btn-block'>
+              Action
+            </button>
+            <button type='button' className='btn btn-default btn-lg btn-block'>
+              Dismiss
+            </button>
+          </div>
+        </div>
+        <div className='col-md-4'>
+          <div className='alert alert-default alert-vertical' role='alert'>
+            <div className='alert-body'>
+              Default. This is sample text.
+              {' '}
+            </div>
+            <button type='button' className='btn btn-default'>
+              Button
+            </button>
+          </div>
+        </div>
+        <div className='col-md-4'>
+          <div className='alert alert-default' role='alert'>
+            <div className='alert-body'>
+              Default. This is sample text.
+              {' '}
+            </div>
+            <button type='button' className='close' data-dismiss='alert' aria-label='Close'>
+              <span aria-hidden='true'>&times;</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <h2>Use cases</h2>
+
+      <h3>Multi lines</h3>
+      <div className='alert alert-danger' role='alert'>
+        <div className='alert-body'>
+          Please update your credit card information to keep your Pro account active. We were not able to process a payment for your Pro account.
+        </div>
+        <button type='button' className='btn btn-default'>
+          Update card
+        </button>
+        <button type='button' className='close' data-dismiss='alert' aria-label='Close'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
       <h3>With heading</h3>
       <div className='alert alert-default' role='alert'>
         <div className='alert-body'>
@@ -63,19 +118,6 @@ export default function Alerts () {
         </div>
       </div>
 
-      <h3>For small display</h3>
-      <div className='alert alert-default alert-vertical' role='alert'>
-        <div className='alert-body'>
-          Default. This is sample text.
-          {' '}
-        </div>
-        <button type='button' className='btn btn-default btn-lg btn-block'>
-          Action
-        </button>
-        <button type='button' className='btn btn-default btn-lg btn-block'>
-          Dismiss
-        </button>
-      </div>
 
     </div>
   )

--- a/demo/tatami/src/client/js/components/alerts.js
+++ b/demo/tatami/src/client/js/components/alerts.js
@@ -4,32 +4,79 @@ export default function Alerts () {
   return (
     <div>
       <h2>Alerts</h2>
-      <div className='alert alert-dismissible alert-success' role='alert'>
-        Well done!
-        {' '}
-        <a href='javascript:;' className='alert-link'>Link</a>
+      <div className='alert alert-default' role='alert'>
+        <div className='alert-body'>
+          Default. This is sample text.
+          {' '}
+        </div>
+        <button type='button' className='btn btn-default'>
+          Button
+        </button>
+      </div>
+      <div className='alert alert-info' role='alert'>
+        <div className='alert-body'>
+          Info. Heads up!
+          {' '}
+          <a href='javascript:;' className='alert-link'>Link</a>
+        </div>
+        <button type='button' className='btn btn-default'>
+          Button
+        </button>
+      </div>
+      <div className='alert alert-success' role='alert'>
+        <div className='alert-body'>
+          Success. Well done!
+          {' '}
+          <a href='javascript:;' className='alert-link'>Link</a>
+        </div>
+        <button type='button' className='btn btn-default'>
+          Button
+        </button>
         <button type='button' className='close' data-dismiss='alert' aria-label='Close'>
           <span aria-hidden='true'>&times;</span>
         </button>
       </div>
-      <div className='alert alert-dismissible alert-info' role='alert'>
-        Heads up!
-        {' '}
-        <a href='javascript:;' className='alert-link'>Link</a>
-        <button type='button' className='close' data-dismiss='alert' aria-label='Close'>
-          <span aria-hidden='true'>&times;</span>
-        </button>
-      </div>
+
       <div className='alert alert-warning' role='alert'>
-        Warning!
-        {' '}
-        <a href='javascript:;' className='alert-link'>Link</a>
+        <div className='alert-body'>
+          Warning. Be careful!
+          {' '}
+          <a href='javascript:;' className='alert-link'>Link</a>
+        </div>
       </div>
       <div className='alert alert-danger' role='alert'>
-        Oh snap!
-        {' '}
-        <a href='javascript:;' className='alert-link'>Link</a>
+        <div className='alert-body'>
+          Danger. Oh snap!
+          {' '}
+          <a href='javascript:;' className='alert-link'>Link</a>
+        </div>
+        <button type='button' className='close' data-dismiss='alert' aria-label='Close'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
       </div>
+
+      <h3>With heading</h3>
+      <div className='alert alert-default' role='alert'>
+        <div className='alert-body'>
+          <h3><strong>Heading title</strong></h3>
+          Effects present letters inquiry no an removed or friends. Desire behind latter me though in. Supposing shameless am he engrossed up additions. My possible peculiar together to. Desire so better am cannot he up before points. Remember mistaken opinions it pleasure of debating.
+        </div>
+      </div>
+
+      <h3>For small display</h3>
+      <div className='alert alert-default alert-vertical' role='alert'>
+        <div className='alert-body'>
+          Default. This is sample text.
+          {' '}
+        </div>
+        <button type='button' className='btn btn-default btn-lg btn-block'>
+          Action
+        </button>
+        <button type='button' className='btn btn-default btn-lg btn-block'>
+          Dismiss
+        </button>
+      </div>
+
     </div>
   )
 }

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -163,7 +163,7 @@ export default function Forms () {
 
         <h3>Validation states</h3>
         <div className="form-group has-success">
-          <label className="control-label" for="inputSuccess1">Input with success</label>
+          <label className="control-label" htmlFor="inputSuccess1">Input with success</label>
           <div className='input-group'>
             <div className='input-group-addon'>scrapbox.io/</div>
             <input type='text' className='form-control' id="inputSuccess1" aria-describedby="helpBlock2" />
@@ -171,14 +171,14 @@ export default function Forms () {
           <span id="helpBlock2" className="help-block">A block of help text that breaks onto a new line and may extend beyond one line.</span>
         </div>
         <div className="form-group has-warning">
-          <label className="control-label" for="inputWarning1">Input with warning</label>
+          <label className="control-label" htmlFor="inputWarning1">Input with warning</label>
           <div className='input-group'>
             <div className='input-group-addon'>scrapbox.io/</div>
             <input type='text' className='form-control' id="inputWarning1" />
           </div>
         </div>
         <div className="form-group has-error">
-          <label className="control-label" for="inputError1">Input with error</label>
+          <label className="control-label" htmlFor="inputError1">Input with error</label>
           <div className='input-group'>
             <div className='input-group-addon'>scrapbox.io/</div>
             <input type='text' className='form-control' id="inputError1" />

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -116,7 +116,7 @@ export default function Forms () {
         <div className='radio'>
           <label>
             <input type='radio' name='optionsRadios' value='option1' />
-            Option one is this and that&mdash;be sure to include why it's great
+            Option one is this and that&mdash;be sure to include why it’s great
           </label>
         </div>
         <div className='radio'>

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -161,6 +161,49 @@ export default function Forms () {
         <br />
         <br />
 
+        <h3>Validation states</h3>
+        <div className="form-group has-success">
+          <label className="control-label" for="inputSuccess1">Input with success</label>
+          <input type="text" className="form-control" id="inputSuccess1" aria-describedby="helpBlock2" />
+          <span id="helpBlock2" className="help-block">A block of help text that breaks onto a new line and may extend beyond one line.</span>
+        </div>
+        <div className="form-group has-warning">
+          <label className="control-label" for="inputWarning1">Input with warning</label>
+          <input type="text" className="form-control" id="inputWarning1" />
+        </div>
+        <div className="form-group has-error">
+          <label className="control-label" for="inputError1">Input with error</label>
+          <input type="text" className="form-control" id="inputError1" />
+        </div>
+        <div className="has-success">
+          <div className="checkbox">
+            <label>
+              <input type="checkbox" id="checkboxSuccess" value="option1" />
+              Checkbox with success
+            </label>
+          </div>
+        </div>
+        <div className="has-warning">
+          <div className="checkbox">
+            <label>
+              <input type="checkbox" id="checkboxWarning" value="option1" />
+              Checkbox with warning
+            </label>
+          </div>
+        </div>
+        <div className="has-error">
+          <div className="checkbox">
+            <label>
+              <input type="checkbox" id="checkboxError" value="option1" />
+              Checkbox with error
+            </label>
+          </div>
+        </div>
+
+        <br /><br />
+        <h3>Progress & Uplaod</h3>
+
+
         <div className='form-group'>
           <label htmlFor='slider'>Process nice score from -20 to +20</label>
           <input type='range' min='-20' max='20' defaultValue='0' data-require-focus-visible-class />

--- a/demo/tatami/src/client/js/components/forms.js
+++ b/demo/tatami/src/client/js/components/forms.js
@@ -164,16 +164,25 @@ export default function Forms () {
         <h3>Validation states</h3>
         <div className="form-group has-success">
           <label className="control-label" for="inputSuccess1">Input with success</label>
-          <input type="text" className="form-control" id="inputSuccess1" aria-describedby="helpBlock2" />
+          <div className='input-group'>
+            <div className='input-group-addon'>scrapbox.io/</div>
+            <input type='text' className='form-control' id="inputSuccess1" aria-describedby="helpBlock2" />
+          </div>
           <span id="helpBlock2" className="help-block">A block of help text that breaks onto a new line and may extend beyond one line.</span>
         </div>
         <div className="form-group has-warning">
           <label className="control-label" for="inputWarning1">Input with warning</label>
-          <input type="text" className="form-control" id="inputWarning1" />
+          <div className='input-group'>
+            <div className='input-group-addon'>scrapbox.io/</div>
+            <input type='text' className='form-control' id="inputWarning1" />
+          </div>
         </div>
         <div className="form-group has-error">
           <label className="control-label" for="inputError1">Input with error</label>
-          <input type="text" className="form-control" id="inputError1" />
+          <div className='input-group'>
+            <div className='input-group-addon'>scrapbox.io/</div>
+            <input type='text' className='form-control' id="inputError1" />
+          </div>
         </div>
         <div className="has-success">
           <div className="checkbox">


### PR DESCRIPTION
Tatami type #36 のマージが前提です。
style guideのalertを適用しました。

### 破壊的変更

ボタンと閉じるボタンを横に並べるため、alertをflexbox化しました。
これにともなって、alert-bodyクラスを新たに作りました。

閉じるボタンが存在するalertに関しては、本文は.alert-bodyクラスにいれなければ動作しません。
文字しかないalertについては、alert-bodyクラスはなくても動作しますが、paddingが普通より小さくなります。（高さは48px）

小さい画面用に要素を縦に並べる .alert-verticalを追加しました。
閉じるボタンを置くときに利用する .alert-dismissableは廃止しました。


### 確認事項

- alertの高さは56pxであること
- 閉じるボタンが縦中央に表示されていること
- 小さい画面でボタン類が崩れないこと
- default以外のスタイルではボタンのborderが表示されないこと。hover, active状態でも。
- stateのカラーが変わったので、fromのエラー等のstateの色も合わせて変更されました。

### 相談事項

- style guideのalert-primaryは追加しませんでした。bootstrapには、statusという概念があって、ここで、success, info, warning, dangerを管理しています。これを崩すと替えるところが多くなるのでとりあえずinfo statusをprimaryと同等の色を使うことにしました。後の検討事項としたいです。

### スクショ

[![Screenshot from Gyazo](https://gyazo.com/b444f08ca9820445e167288d08043e08/raw)](https://gyazo.com/b444f08ca9820445e167288d08043e08)