### PR TITLE
Tatami nav

### DIFF
--- a/assets/stylesheets/bootstrap/_buttons.scss
+++ b/assets/stylesheets/bootstrap/_buttons.scss
@@ -90,7 +90,7 @@ a.btn {
 }
 // Transparent
 .btn-clear {
-  @include button-transparent($btn-default-color);
+  @include button-transparent($btn-clear-color, $btn-clear-bg, $btn-clear-border);
 }
 
 .file-upload-btn {

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -20,14 +20,18 @@
       position: relative;
       display: block;
       padding: $nav-link-padding;
+      color: $nav-link-color;
+      line-height: $line-height-base;
 
       &:active {
+        color: $nav-link-color;
         text-decoration: none;
         background-color: $nav-link-hover-bg;
       }
 
       [data-hover-visible] &:hover,
       [data-focus-visible] &:focus {
+        color: $nav-link-color;
         text-decoration: none;
         background-color: $nav-link-hover-bg;
       }
@@ -60,7 +64,6 @@
     [data-hover-visible] &:hover,
     [data-focus-visible] &:focus {
       background-color: $nav-link-hover-bg;
-      border-color: $link-color;
     }
   }
 
@@ -74,6 +77,18 @@
   }
 }
 
+// Large
+
+.nav-lg {
+  > li {
+    > a {
+      font-size: $font-size-large;
+      padding: $nav-link-padding-lg;
+      line-height: $line-height-large;
+    }
+  }
+}
+
 
 // Tabs
 // -------------------------
@@ -81,19 +96,24 @@
 // Give the tabs something to sit on
 .nav-tabs {
   border-bottom: 1px solid $nav-tabs-border-color;
+
   > li {
     // Make the list-items overlay the bottom border
     margin-bottom: -1px;
 
     // Actual tabs (as links)
     > a {
-      margin-right: 2px;
-      line-height: $line-height-base;
-      border: 1px solid transparent;
-      border-radius: $border-radius-base $border-radius-base 0 0;
+      margin-right: -1px;
+      border: 1px solid $nav-tabs-border-color;
+      border-radius: 0;
+      background-color: $nav-tabs-link-bg;
+      color: $nav-tabs-link-color;
 
-      [data-hover-visible] &:hover {
-        border-color: $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color;
+      &:active,
+      [data-hover-visible] &:hover,
+      [data-focus-visible] &:focus {
+        color: $nav-tabs-link-color;
+        background-color: $nav-tabs-link-hover-bg;
       }
     }
 
@@ -106,16 +126,39 @@
         color: $nav-tabs-active-link-hover-color;
         background-color: $nav-tabs-active-link-hover-bg;
         border: 1px solid $nav-tabs-active-link-hover-border-color;
-        border-bottom-color: transparent;
+        border-bottom-color: $nav-tabs-active-link-hover-bg;
         cursor: default;
+      }
+    }
+
+
+    &:first-of-type {
+      > a {
+        border-radius: $border-radius-base 0 0 0;
+      }
+    }
+
+    &:last-of-type {
+      > a {
+        border-radius: 0 $border-radius-base 0 0;
       }
     }
   }
   // pulling this in mainly for less shorthand
   &.nav-justified {
     @extend .nav-justified;
-    @extend .nav-tabs-justified;
   }
+}
+
+.tab-content {
+  background-color: $nav-tabs-active-link-hover-bg;
+  border: 1px solid $nav-tabs-border-color;
+  border-radius: 0 0 $border-radius-base $border-radius-base;
+  border-top: 0;
+}
+
+.tab-pane {
+  padding: 32px;
 }
 
 
@@ -126,6 +169,7 @@
     // Links rendered as pills
     > a {
       border-radius: $nav-pills-border-radius;
+      border: 1px transparent solid;
       margin-right: 2px;
     }
 
@@ -171,7 +215,6 @@
   > li {
     > a {
       text-align: center;
-      margin-bottom: 5px;
     }
   }
 
@@ -179,54 +222,7 @@
     top: auto;
     left: auto;
   }
-
-  @media (min-width: $screen-sm-min) {
-    > li {
-      > a {
-        margin-bottom: 0;
-      }
-    }
-  }
 }
-
-// Move borders to anchors instead of bottom of list
-//
-// Mixin for adding on top the shared `.nav-justified` styles for our tabs
-.nav-tabs-justified {
-  border-bottom: 0;
-
-  > li > a {
-    // Override margin from .nav-tabs
-    margin-right: 0;
-    border-radius: $border-radius-base;
-  }
-
-  > .active > a {
-    &,
-    &:active,
-    [data-hover-visible] &:hover,
-    [data-focus-visible] &:focus {
-      border: 1px solid $nav-tabs-justified-link-border-color;
-    }
-
-  }
-
-  @media (min-width: $screen-sm-min) {
-    > li > a {
-      border-bottom: 1px solid $nav-tabs-justified-link-border-color;
-      border-radius: $border-radius-base $border-radius-base 0 0;
-    }
-    > .active > a {
-      &,
-      &:active,
-      [data-hover-visible] &:hover,
-      [data-focus-visible] &:focus {
-        border-bottom-color: $nav-tabs-justified-active-link-border-color;
-      }
-    }
-  }
-}
-
 
 // Tabbable tabs
 // -------------------------

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -95,8 +95,6 @@
 
 // Give the tabs something to sit on
 .nav-tabs {
-  border-bottom: 1px solid $nav-tabs-border-color;
-
   > li {
     // Make the list-items overlay the bottom border
     margin-bottom: -1px;
@@ -153,8 +151,7 @@
 .tab-content {
   background-color: $nav-tabs-active-link-hover-bg;
   border: 1px solid $nav-tabs-border-color;
-  border-radius: 0 0 $border-radius-base $border-radius-base;
-  border-top: 0;
+  border-radius: 0 $border-radius-base $border-radius-base $border-radius-base;
 }
 
 .tab-pane {

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -201,6 +201,13 @@
   }
 }
 
+.nav-stacked-fixed {
+  > li {
+    > a {
+      border-radius: 0;
+    }
+  }
+}
 
 // Nav variations
 // --------------------------------------------------

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -193,7 +193,6 @@
       margin-right: 0; // no need for this gap between nav items
     }
     + li {
-      margin-top: 2px;
     }
   }
 }

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -177,6 +177,10 @@ $btn-danger-color:               #fff !default;
 $btn-danger-bg:                  $brand-danger !default;
 $btn-danger-border:              $brand-danger !default;
 
+$btn-clear-color:                $text-color !default;
+$btn-clear-bg:                   rgba(0, 0, 0, .05) !default;
+$btn-clear-border:               transparent !default;
+
 $btn-link-disabled-color:        $gray-light !default;
 
 // Allows for customizing button radius independently from global border radius
@@ -426,23 +430,26 @@ $navbar-inverse-toggle-border-color:        #333 !default;
 //##
 
 //=== Shared nav styles
-$nav-link-padding:                          10px 15px !default;
-$nav-link-hover-bg:                         $gray-lighter !default;
+$nav-link-padding:                          5px 16px !default;
+$nav-link-color:                            $text-color !default;
+$nav-link-hover-bg:                         $btn-clear-bg !default;
 
 $nav-disabled-link-color:                   $gray-light !default;
 $nav-disabled-link-hover-color:             $gray-light !default;
 
-//== Tabs
-$nav-tabs-border-color:                     #ddd !default;
+$nav-link-padding-lg:                       11px 24px !default;
 
+//== Tabs
+$nav-tabs-link-color:                       $nav-link-color !default;
+$nav-tabs-link-bg:                          lighten($gray-base, 90%) !default;
+$nav-tabs-border-color:                     lighten($gray-base, 80%) !default;
+
+$nav-tabs-link-hover-bg:                    darken($nav-tabs-link-bg, 5%) !default;
 $nav-tabs-link-hover-border-color:          $gray-lighter !default;
 
-$nav-tabs-active-link-hover-bg:             $body-bg !default;
-$nav-tabs-active-link-hover-color:          $gray !default;
-$nav-tabs-active-link-hover-border-color:   #ddd !default;
-
-$nav-tabs-justified-link-border-color:            #ddd !default;
-$nav-tabs-justified-active-link-border-color:     $body-bg !default;
+$nav-tabs-active-link-hover-bg:             #fff !default;
+$nav-tabs-active-link-hover-color:          $text-color !default;
+$nav-tabs-active-link-hover-border-color:   $nav-tabs-border-color !default;
 
 //== Pills
 $nav-pills-border-radius:                   $border-radius-base !default;
@@ -681,7 +688,7 @@ $progress-bar-info-bg:        $brand-info !default;
 //** Background color on `.list-group-item`
 $list-group-bg:                 #fff !default;
 //** `.list-group-item` border color
-$list-group-border:             #ddd !default;
+$list-group-border:             lighten($gray-base, 80%) !default;
 //** List group border radius
 $list-group-border-radius:      $border-radius-base !default;
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -201,7 +201,7 @@ $input-bg-disabled:              $gray-lighter !default;
 //** Text color for `<input>`s
 $input-color:                    $gray !default;
 //** `<input>` border color
-$input-border:                   #ccc !default;
+$input-border:                   lighten($gray-base, 80%) !default;
 
 // TODO: Rename `$input-border-radius` to `$input-border-radius-base` in v4
 //** Default `.form-control` border radius
@@ -226,7 +226,7 @@ $input-height-large:             (ceil($font-size-large * $line-height-large) + 
 $input-height-small:             (floor($font-size-small * $line-height-small) + ($padding-small-vertical * 2) + 2) !default;
 
 //** `.form-group` margin
-$form-group-margin-bottom:       15px !default;
+$form-group-margin-bottom:       16px !default;
 
 $legend-color:                   $text-color !default;
 $legend-border-color:            #e5e5e5 !default;

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -441,10 +441,10 @@ $nav-link-padding-lg:                       11px 24px !default;
 
 //== Tabs
 $nav-tabs-link-color:                       $nav-link-color !default;
-$nav-tabs-link-bg:                          lighten($gray-base, 90%) !default;
+$nav-tabs-link-bg:                          rgba(0, 0, 0, 0.05) !default;
 $nav-tabs-border-color:                     lighten($gray-base, 80%) !default;
 
-$nav-tabs-link-hover-bg:                    darken($nav-tabs-link-bg, 5%) !default;
+$nav-tabs-link-hover-bg:                    rgba(0, 0, 0, 0.1) !default;
 $nav-tabs-link-hover-border-color:          $gray-lighter !default;
 
 $nav-tabs-active-link-hover-bg:             #fff !default;

--- a/assets/stylesheets/bootstrap/forms/normalize.scss
+++ b/assets/stylesheets/bootstrap/forms/normalize.scss
@@ -26,7 +26,7 @@ legend {
 
 label {
   display: inline-block;
-  margin-bottom: 5px;
+  margin-bottom: 4px;
   font-weight: bold;
 }
 

--- a/assets/stylesheets/bootstrap/mixins/_buttons.scss
+++ b/assets/stylesheets/bootstrap/mixins/_buttons.scss
@@ -59,26 +59,26 @@
   }
 }
 
-@mixin button-transparent($color) {
+@mixin button-transparent($color, $background, $border) {
   color: $color;
   background-color: transparent;
-  border-color: transparent;
+  border-color: $border;
 
   [data-focus-visible] &:focus {
     color: $color;
-    background-color: rgba(0, 0, 0, .05);
+    background-color: $background;
   }
 
   [data-hover-visible] &:hover {
     color: $color;
-    background-color: rgba(0, 0, 0, .05);
+    background-color: $background;
   }
 
   &:active,
   &.active,
   .open > &.dropdown-toggle {
     color: $color;
-    background-color: rgba(0, 0, 0, .05);
+    background-color: $background;
 
     [data-hover-visible] &:hover,
     [data-focus-visible] &:focus {
@@ -96,8 +96,8 @@
   fieldset[disabled] & {
     [data-hover-visible] &:hover,
     [data-focus-visible] &:focus {
-      background-color: transparent;
-          border-color: transparent;
+      background-color: $background;
+          border-color: $border;
     }
   }
 

--- a/demo/tatami/src/client/css/bootstrap_loader.scss
+++ b/demo/tatami/src/client/css/bootstrap_loader.scss
@@ -39,7 +39,7 @@
 @import "bootstrap/alerts";
 // @import "bootstrap/progress-bars";
 // @import "bootstrap/media";
-// @import "bootstrap/list-group";
+@import "bootstrap/list-group";
 @import "bootstrap/panels";
 // @import "bootstrap/responsive-embed";
 @import "bootstrap/wells";

--- a/demo/tatami/src/client/js/components/alerts.js
+++ b/demo/tatami/src/client/js/components/alerts.js
@@ -55,7 +55,6 @@ export default function Alerts () {
         </button>
       </div>
 
-
       <h3>Small size</h3>
       <div className='row'>
         <div className='col-md-4'>
@@ -110,6 +109,7 @@ export default function Alerts () {
           <span aria-hidden='true'>&times;</span>
         </button>
       </div>
+
       <h3>With heading</h3>
       <div className='alert alert-default' role='alert'>
         <div className='alert-body'>
@@ -117,8 +117,6 @@ export default function Alerts () {
           Effects present letters inquiry no an removed or friends. Desire behind latter me though in. Supposing shameless am he engrossed up additions. My possible peculiar together to. Desire so better am cannot he up before points. Remember mistaken opinions it pleasure of debating.
         </div>
       </div>
-
-
     </div>
   )
 }

--- a/demo/tatami/src/client/js/components/navs.js
+++ b/demo/tatami/src/client/js/components/navs.js
@@ -3,30 +3,37 @@ import React from 'react'
 export default function Navs () {
   return (
     <div>
-      <h2>Navs</h2>
+      <h1>Navs</h1>
 
-      <h4>Tabs</h4>
+      <h3>Tabs</h3>
       <div>
         <ul className='nav nav-tabs' role='tablist'>
-          <li role='presentation' className='active'><a href='#home' aria-controls='home' role='tab' data-toggle='tab'>Home</a></li>
-          <li role='presentation'><a href='#profile' aria-controls='profile' role='tab' data-toggle='tab'>Profile</a></li>
+          <li role='presentation' className='active'>
+            <a href='#home' aria-controls='home' role='tab' data-toggle='tab' aria-expanded='true'>Home</a>
+          </li>
+          <li role='presentation'>
+            <a href='#profile' aria-controls='profile' role='tab' data-toggle='tab' aria-expanded='false'>Profile</a>
+          </li>
+          <li role='presentation'>
+            <a href='#settings' aria-controls='settings' role='tab' data-toggle='tab' aria-expanded='false'>Settings</a>
+          </li>
         </ul>
-        <div className='tab-content'>
-          <div role='tabpanel' className='tab-pane active' id='home'>
-            <br />
+        <div className='tab-content' id='myTabContent'>
+          <div role='tabpanel' className='tab-pane active' id='home' aria-labelledby='home-tab'>
             this is home...
           </div>
           <div role='tabpanel' className='tab-pane' id='profile'>
-            <br />
             this is profile...
+          </div>
+          <div role='tabpanel' className='tab-pane' id='settings'>
+            this is settings...
           </div>
         </div>
       </div>
 
-      <br />
-      <br />
+      <br /><br />
 
-      <h4>Pills</h4>
+      <h3>Pills</h3>
       <ul className='nav nav-pills'>
         <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
         <li role='presentation'><a href='javascript:;'>Profile</a></li>
@@ -42,20 +49,18 @@ export default function Navs () {
         </li>
       </ul>
 
-      <br />
-      <br />
+      <br /><br />
 
-      <h4>Stacked pills</h4>
+      <h3>Stacked pills</h3>
       <ul className='nav nav-pills nav-stacked'>
         <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
         <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
         <li role='presentation'><a href='javascript:;'>Messages</a></li>
       </ul>
 
-      <br />
-      <br />
+      <br /><br />
 
-      <h4>Justified</h4>
+      <h3>Justified</h3>
       <ul className='nav nav-tabs nav-justified' role='tablist'>
         <li role='presentation' className='active'><a href='#home' aria-controls='home' role='tab' data-toggle='tab'>Home</a></li>
         <li role='presentation'><a href='#profile' aria-controls='profile' role='tab' data-toggle='tab'>Profile</a></li>
@@ -68,6 +73,88 @@ export default function Navs () {
         <li role='presentation'><a href='javascript:;'>Messages</a></li>
       </ul>
 
+      <br /><br />
+
+      <h2>Large size</h2>
+
+      <h3>Tabs</h3>
+      <div>
+        <ul className='nav nav-tabs nav-lg' role='tablist'>
+          <li role='presentation' className='active'>
+            <a href='#home-lg' aria-controls='home-lg' role='tab' data-toggle='tab'>Home</a>
+          </li>
+          <li role='presentation'>
+            <a href='#profile-lg' aria-controls='profile-lg' role='tab' data-toggle='tab'>Profile</a>
+          </li>
+          <li role='presentation'>
+            <a href='#settings-lg' aria-controls='settings-lg' role='tab' data-toggle='tab'>Settings</a>
+          </li>
+        </ul>
+        <div className='tab-content'>
+          <div role='tabpanel' className='tab-pane active' id='home-lg'>
+            this is home...
+          </div>
+          <div role='tabpanel' className='tab-pane' id='profile-lg'>
+            this is profile...
+          </div>
+          <div role='tabpanel' className='tab-pane' id='settings-lg'>
+            this is settings...
+          </div>
+        </div>
+      </div>
+
+      <br /><br />
+
+      <h3>Pills</h3>
+      <ul className='nav nav-pills nav-lg'>
+        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+        <li role='presentation'><a href='javascript:;'>Profile</a></li>
+        <li role='presentation'><a href='javascript:;'>Messages</a></li>
+        <li role='presentation' className='dropdown'>
+          <a className='dropdown-toggle' data-toggle='dropdown' href='#' role='button' aria-haspopup='true' aria-expanded='false'>
+            Dropdown <span className='caret'></span>
+          </a>
+          <ul className='dropdown-menu'>
+            <li><a href='javascript:;'>Action</a></li>
+            <li><a href='javascript:;'>Another action</a></li>
+          </ul>
+        </li>
+      </ul>
+
+      <br /><br />
+
+      <h3>Stacked pills</h3>
+      <ul className='nav nav-pills nav-stacked nav-lg'>
+        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+        <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+        <li role='presentation'><a href='javascript:;'>Messages</a></li>
+      </ul>
+
+      <br /><br />
+
+      <h3>Justified</h3>
+      <ul className='nav nav-tabs nav-justified nav-lg' role='tablist'>
+        <li role='presentation' className='active'><a href='#home' aria-controls='home' role='tab' data-toggle='tab'>Home</a></li>
+        <li role='presentation'><a href='#profile' aria-controls='profile' role='tab' data-toggle='tab'>Profile</a></li>
+        <li role='presentation'><a href='#messages' aria-controls='profile' role='tab' data-toggle='tab'>Messages</a></li>
+      </ul>
+      <br />
+      <ul className='nav nav-pills nav-justified nav-lg'>
+        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+        <li role='presentation'><a href='javascript:;'>Profile</a></li>
+        <li role='presentation'><a href='javascript:;'>Messages</a></li>
+      </ul>
+
+      <h2>List group</h2>
+      <div className='list-group'>
+        <a href='javascript:;' className='list-group-item active'>
+          Cras justo odio
+        </a>
+        <a href='javascript:;' className='list-group-item'>Dapibus ac facilisis in</a>
+        <a href='javascript:;' className='list-group-item'>Morbi leo risus</a>
+        <a href='javascript:;' className='list-group-item'>Porta ac consectetur ac</a>
+        <a href='javascript:;' className='list-group-item'>Vestibulum at eros</a>
+      </div>
     </div>
   )
 }

--- a/demo/tatami/src/client/js/components/navs.js
+++ b/demo/tatami/src/client/js/components/navs.js
@@ -58,6 +58,13 @@ export default function Navs () {
         <li role='presentation'><a href='javascript:;'>Messages</a></li>
       </ul>
 
+      <h3>Stacked pills fixed</h3>
+      <ul className='nav nav-pills nav-stacked nav-stacked-fixed'>
+        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+        <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+        <li role='presentation'><a href='javascript:;'>Messages</a></li>
+      </ul>
+
       <br /><br />
 
       <h3>Justified</h3>
@@ -125,6 +132,13 @@ export default function Navs () {
 
       <h3>Stacked pills</h3>
       <ul className='nav nav-pills nav-stacked nav-lg'>
+        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+        <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+        <li role='presentation'><a href='javascript:;'>Messages</a></li>
+      </ul>
+
+      <h3>Stacked pills fixed</h3>
+      <ul className='nav nav-pills nav-stacked nav-stacked-fixed nav-lg'>
         <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
         <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
         <li role='presentation'><a href='javascript:;'>Messages</a></li>


### PR DESCRIPTION
Tatami alert #37 のマージが前提です。

### 動作確認

- tabのタブ間隔がゼロになったこと
- 色とborder colorがあっていること
- tabもpillsも高さが36px であること
- largeサイズは高さが48pxであること


### style guideからの変更点
背景色が白ではなくグレー基調で作っているのでtabとpillsのhoverカラーは変更しました。
白背景でも動くはずです。

style guideのVertical nav pill は bootstrap用語では stacked nav pill になります。

サイズですが、stacked nav pillsはmargin-topが2px入っているので、これは残しました。このあたり要検討。

### できていない点

- アイコンを含めた場合の設計はやっていません
- verticalのborderedもまだ作っていません
 bootstrapにはlist-groupというモバイルのテーブル用のコンポーネントがあって、これを使うべきか、navでいくのかまだ結論がでていないためです。参考のため。list-groupも追加しておきました。

### スクショ

[![Screenshot from Gyazo](https://gyazo.com/b68bf2f1d54cfcc2e6b7f609c72d4b82/raw)](https://gyazo.com/b68bf2f1d54cfcc2e6b7f609c72d4b82)


[![Screenshot from Gyazo](https://gyazo.com/9b206163b0f02a62396e43cb9dfe08d7/raw)](https://gyazo.com/9b206163b0f02a62396e43cb9dfe08d7)