### PR TITLE
Tatami dropdown

### DIFF
--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -77,15 +77,6 @@
       font-size: 15px;
       line-height: $line-height-computed;
       padding: 8px 24px;
-
-        // hover / focus
-        &:active,
-        [data-hover-visible] &:hover,
-        [data-focus-visible] &:focus {
-          text-decoration: none;
-          color: $dropdown-link-color;
-          background-color: darken($btn-default-bg, 10%);
-        }
     }
 
     .dropdown-header {
@@ -93,10 +84,9 @@
       font-size: 14px;
     }
   }
-
 }
 
-// Hover/Focus state
+// Active/Hover/Focus state
 .dropdown-menu > li > a {
   &:active,
   [data-hover-visible] &:hover,
@@ -118,7 +108,7 @@
   }
 }
 
-// Active state
+// Active state (XXX: The naming is bad, it conflicts :active, so we recommend to use .selected)
 .dropdown-menu > .active > a {
   &,
   &:active,
@@ -130,6 +120,43 @@
     background-color: $dropdown-link-active-bg;
   }
 }
+
+// Selected state
+.dropdown-menu > .selected > a {
+  color: $brand-primary;
+}
+
+// Light gray hover style
+.dropdown-menu-light-hover-style {
+  > li > a {
+    // hover / focus
+    [data-hover-visible] &:hover,
+    [data-focus-visible] &:focus {
+      text-decoration: none;
+      color: $dropdown-link-color;
+      background-color: darken($btn-default-bg, 5%);
+    }
+
+    // hover / focus
+    &:active {
+      &,
+      [data-hover-visible] &:hover,
+      [data-focus-visible] &:focus {
+
+        text-decoration: none;
+        color: $dropdown-link-color;
+        background-color: darken($btn-default-bg, 10%);
+
+      }
+    }
+  }
+
+  > .selected > a {
+    color: $brand-primary !important;
+  }
+}
+
+
 
 // Disabled state
 //

--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -38,7 +38,7 @@
   background-color: $dropdown-bg;
   border: 1px solid $dropdown-border;
   border-radius: $border-radius-base;
-  @include box-shadow(0 6px 12px rgba(0,0,0,.175));
+  box-shadow: 0 4px 10px rgba(0,0,0,.175);
   background-clip: padding-box;
 
   // Aligns the dropdown menu to right
@@ -67,6 +67,35 @@
   }
 }
 
+// Large size
+
+.dropdown-menu {
+  &.dropdown-menu-lg {
+    padding: 8px 0;
+
+    > li > a {
+      font-size: 15px;
+      line-height: $line-height-computed;
+      padding: 8px 24px;
+
+        // hover / focus
+        &:active,
+        [data-hover-visible] &:hover,
+        [data-focus-visible] &:focus {
+          text-decoration: none;
+          color: $dropdown-link-color;
+          background-color: darken($btn-default-bg, 10%);
+        }
+    }
+
+    .dropdown-header {
+      padding: 3px 24px;
+      font-size: 14px;
+    }
+  }
+
+}
+
 // Hover/Focus state
 .dropdown-menu > li > a {
   &:active,
@@ -75,6 +104,10 @@
     text-decoration: none;
     color: $dropdown-link-hover-color;
     background-color: $dropdown-link-hover-bg;
+  }
+
+  [data-focus-visible] &:focus {
+    box-shadow: none;
   }
 }
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -247,16 +247,16 @@ $cursor-disabled:                not-allowed !default;
 //** Background for the dropdown menu.
 $dropdown-bg:                    #fff !default;
 //** Dropdown menu `border-color`.
-$dropdown-border:                rgba(0,0,0,.15) !default;
+$dropdown-border:                rgba(0,0,0,.1) !default;
 //** Divider color for between dropdown items.
 $dropdown-divider-bg:            #e5e5e5 !default;
 
 //** Dropdown link text color.
 $dropdown-link-color:            $text-color !default;
 //** Hover color for dropdown links.
-$dropdown-link-hover-color:      darken($text-color, 5%) !default;
+$dropdown-link-hover-color:      $component-active-color !default;
 //** Hover background for dropdown links.
-$dropdown-link-hover-bg:         #f5f5f5 !default;
+$dropdown-link-hover-bg:         $component-active-bg !default;
 
 //** Active dropdown menu item text color.
 $dropdown-link-active-color:     $component-active-color !default;

--- a/demo/tatami/src/client/js/components/dropdowns.js
+++ b/demo/tatami/src/client/js/components/dropdowns.js
@@ -14,7 +14,7 @@ export default function Dropdowns () {
           <li><a href='javascript:;'>Save</a></li>
           <li><a href='javascript:;'>Open in Chrome</a></li>
           <li role='separator' className='divider' />
-          <li className='active'><a href='javascript:;'>Active link</a></li>
+          <li className='selected'><a href='javascript:;'>Selected link</a></li>
           <li className='disabled'><a href='javascript:;'>Disabled link</a></li>
         </ul>
       </div>
@@ -32,7 +32,7 @@ export default function Dropdowns () {
           <li><a href='javascript:;'>Save</a></li>
           <li><a href='javascript:;'>Open in Chrome</a></li>
           <li role='separator' className='divider' />
-          <li className='active'><a href='javascript:;'>Active link</a></li>
+          <li className='selected'><a href='javascript:;'>Selected link</a></li>
           <li className='disabled'><a href='javascript:;'>Disabled link</a></li>
         </ul>
       </div>
@@ -80,7 +80,27 @@ export default function Dropdowns () {
           <li><a href='javascript:;'>Save</a></li>
           <li><a href='javascript:;'>Open in Chrome</a></li>
           <li><a href='javascript:;'>Print</a></li>
-          <li><a href='javascript:;'>Share</a></li>
+          <li className='selected'><a href='javascript:;'>Share</a></li>
+          <li className='dropdown-header'>Header</li>
+          <li><a href='javascript:;'>Download</a></li>
+          <li><a href='javascript:;'>Delete</a></li>
+        </ul>
+      </div>
+
+      <h3>Light hover style</h3>
+
+      <div className='dropdown'>
+        <button className='btn btn-clear btn-lg dropdown-toggle' type='button' id='dropdownMenu2'
+          tabIndex='0'
+          data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
+          Dropdown <span className='caret' />
+        </button>
+        <ul className='dropdown-menu dropdown-menu-lg dropdown-menu-light-hover-style' aria-labelledby='dropdownMenu2'>
+          <li><a href='javascript:;'>New</a></li>
+          <li><a href='javascript:;'>Save</a></li>
+          <li><a href='javascript:;'>Open in Chrome</a></li>
+          <li><a href='javascript:;'>Print</a></li>
+          <li className='selected'><a href='javascript:;'>Share</a></li>
           <li className='dropdown-header'>Header</li>
           <li><a href='javascript:;'>Download</a></li>
           <li><a href='javascript:;'>Delete</a></li>

--- a/demo/tatami/src/client/js/components/dropdowns.js
+++ b/demo/tatami/src/client/js/components/dropdowns.js
@@ -3,22 +3,24 @@ import React from 'react'
 export default function Dropdowns () {
   return (
     <div>
-      <h2>Dropdowns</h2>
+      <h1>Dropdowns</h1>
       <div className='dropdown'>
         <button className='btn btn-default dropdown-toggle' type='button' id='dropdownMenu1'
           data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
           Dropdown <span className='caret' />
         </button>
         <ul className='dropdown-menu' aria-labelledby='dropdownMenu1'>
-          <li><a href='javascript:;'>Action</a></li>
-          <li><a href='javascript:;'>Another action</a></li>
-          <li><a href='javascript:;'>Something else here</a></li>
+          <li><a href='javascript:;'>New</a></li>
+          <li><a href='javascript:;'>Save</a></li>
+          <li><a href='javascript:;'>Open in Chrome</a></li>
           <li role='separator' className='divider' />
           <li className='active'><a href='javascript:;'>Active link</a></li>
           <li className='disabled'><a href='javascript:;'>Disabled link</a></li>
         </ul>
       </div>
-      <hr />
+
+      <br /><br />
+
       <div className='dropdown'>
         <button className='btn btn-clear dropdown-toggle' type='button' id='dropdownMenu2'
           tabIndex='0'
@@ -26,17 +28,16 @@ export default function Dropdowns () {
           Dropdown <span className='caret' />
         </button>
         <ul className='dropdown-menu' aria-labelledby='dropdownMenu2'>
-          <li><a href='javascript:;'>Action</a></li>
-          <li><a href='javascript:;'>Another action</a></li>
-          <li><a href='javascript:;'>Something else here</a></li>
+          <li><a href='javascript:;'>New</a></li>
+          <li><a href='javascript:;'>Save</a></li>
+          <li><a href='javascript:;'>Open in Chrome</a></li>
           <li role='separator' className='divider' />
           <li className='active'><a href='javascript:;'>Active link</a></li>
           <li className='disabled'><a href='javascript:;'>Disabled link</a></li>
         </ul>
       </div>
 
-      <br />
-      <br />
+      <br /><br />
 
       <div className='btn-group'>
         <button type='button' className='btn btn-danger'>Action</button>
@@ -45,11 +46,11 @@ export default function Dropdowns () {
           <span className='sr-only'>Toggle Dropdown</span>
         </button>
         <ul className='dropdown-menu'>
-          <li><a href='#'>Action</a></li>
-          <li><a href='#'>Another action</a></li>
-          <li><a href='#'>Something else here</a></li>
+          <li><a href='javascript:;'>New</a></li>
+          <li><a href='javascript:;'>Save</a></li>
+          <li><a href='javascript:;'>Open in Chrome</a></li>
           <li role='separator' className='divider'></li>
-          <li><a href='#'>Separated link</a></li>
+          <li><a href='javascript:;'>Delete</a></li>
         </ul>
       </div>
       {' '}
@@ -60,8 +61,29 @@ export default function Dropdowns () {
           <span className='sr-only'>Toggle Dropdown</span>
         </button>
         <ul className='dropdown-menu'>
-          <li><a href='#'>Action</a></li>
-          <li><a href='#'>Another action</a></li>
+          <li><a href='javascript:;'>Action</a></li>
+          <li><a href='javascript:;'>Another action</a></li>
+        </ul>
+      </div>
+
+      <br /><br />
+      <h3>Large size</h3>
+
+      <div className='dropdown'>
+        <button className='btn btn-clear btn-lg dropdown-toggle' type='button' id='dropdownMenu2'
+          tabIndex='0'
+          data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
+          Dropdown <span className='caret' />
+        </button>
+        <ul className='dropdown-menu dropdown-menu-lg' aria-labelledby='dropdownMenu2'>
+          <li><a href='javascript:;'>New</a></li>
+          <li><a href='javascript:;'>Save</a></li>
+          <li><a href='javascript:;'>Open in Chrome</a></li>
+          <li><a href='javascript:;'>Print</a></li>
+          <li><a href='javascript:;'>Share</a></li>
+          <li className='dropdown-header'>Header</li>
+          <li><a href='javascript:;'>Download</a></li>
+          <li><a href='javascript:;'>Delete</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
### 概要

- 小さいサイズのときのhoverをブルーにした
- dropdown-menu-lg を作成

### 議論

styleguideのlgサイズがスマホでも大きすぎると感じます。
高さ48が大きすぎたので、40にした。またフォントサイズを15pxにしてみました。

### スクショ

[![Screenshot from Gyazo](https://gyazo.com/246320227459b7280037808d460a26cf/raw)](https://gyazo.com/246320227459b7280037808d460a26cf)