### PR TITLE
navsでアイコンやサムネールを使えるようにする

### DIFF
--- a/assets/stylesheets/bootstrap/_mixins.scss
+++ b/assets/stylesheets/bootstrap/_mixins.scss
@@ -15,6 +15,7 @@
 @import "mixins/text-emphasis";
 @import "mixins/text-overflow";
 @import "mixins/vendor-prefixes";
+@import "mixins/color";
 
 // Components
 @import "mixins/alerts";

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -201,7 +201,7 @@
         // Forward icon
         &:first-child {
           float: left;
-          margin-right: 12px;
+          margin-right: 10px;
         }
 
         // Backward icon
@@ -218,7 +218,7 @@
         width: 24px;
         height: 24px;
         float: left;
-        margin-right: 12px;
+        margin-right: 10px;
       }
     }
   }
@@ -227,16 +227,17 @@
   &.nav-lg > li > a {
     .kamon {
       &:first-child {
-        margin-right: 20px;
+        margin-right: 14px;
       }
 
       &:last-child {
-        margin-left: 20px;
+        margin-right: -2px;
+        margin-left: 16px;
       }
     }
 
     .nav-stacked-thumbnail {
-      margin-right: 20px;
+      margin-right: 14px;
     }
   }
 }

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -207,6 +207,7 @@
         // Backward icon
         &:last-child {
           float: right;
+          margin-right: -4px;
           margin-left: 12px;
           opacity: .5;
         }

--- a/assets/stylesheets/bootstrap/_navs.scss
+++ b/assets/stylesheets/bootstrap/_navs.scss
@@ -20,18 +20,18 @@
       position: relative;
       display: block;
       padding: $nav-link-padding;
-      color: $nav-link-color;
       line-height: $line-height-base;
+      @include color-and-fill($nav-link-color);
 
       &:active {
-        color: $nav-link-color;
+        @include color-and-fill($nav-link-color);
         text-decoration: none;
         background-color: $nav-link-hover-bg;
       }
 
       [data-hover-visible] &:hover,
       [data-focus-visible] &:focus {
-        color: $nav-link-color;
+        @include color-and-fill($nav-link-color);
         text-decoration: none;
         background-color: $nav-link-hover-bg;
       }
@@ -39,12 +39,12 @@
 
     // Disabled state sets text to gray and nukes hover/tab effects
     &.disabled > a {
-      color: $nav-disabled-link-color;
+      @include color-and-fill($nav-disabled-link-color);
 
       &:active,
       [data-hover-visible] &:hover,
       [data-focus-visible] &:focus {
-        color: $nav-disabled-link-hover-color;
+        @include color-and-fill($nav-disabled-link-hover-color);
         text-decoration: none;
         background-color: transparent;
         cursor: $cursor-disabled;
@@ -176,7 +176,7 @@
       &:active,
       [data-hover-visible] &:hover,
       [data-focus-visible] &:focus {
-        color: $nav-pills-active-link-hover-color;
+        @include color-and-fill($nav-pills-active-link-hover-color);
         background-color: $nav-pills-active-link-hover-bg;
       }
     }
@@ -191,11 +191,55 @@
   > li {
     > a {
       margin-right: 0; // no need for this gap between nav items
+
+      // Icons
+      .kamon {
+        width: $icon-size-large;
+        height: $icon-size-large;
+        vertical-align: middle;
+
+        // Forward icon
+        &:first-child {
+          float: left;
+          margin-right: 12px;
+        }
+
+        // Backward icon
+        &:last-child {
+          float: right;
+          margin-left: 12px;
+          opacity: .5;
+        }
+      }
+
+      // Thumbnails
+      .nav-stacked-thumbnail {
+        width: 24px;
+        height: 24px;
+        float: left;
+        margin-right: 12px;
+      }
     }
-    + li {
+  }
+
+  // Icons and thumbnails for large size
+  &.nav-lg > li > a {
+    .kamon {
+      &:first-child {
+        margin-right: 20px;
+      }
+
+      &:last-child {
+        margin-left: 20px;
+      }
+    }
+
+    .nav-stacked-thumbnail {
+      margin-right: 20px;
     }
   }
 }
+
 
 .nav-stacked-fixed {
   > li {

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -430,14 +430,14 @@ $navbar-inverse-toggle-border-color:        #333 !default;
 //##
 
 //=== Shared nav styles
-$nav-link-padding:                          5px 16px !default;
+$nav-link-padding:                          5px 11px !default;
 $nav-link-color:                            $text-color !default;
 $nav-link-hover-bg:                         $btn-clear-bg !default;
 
 $nav-disabled-link-color:                   $gray-light !default;
 $nav-disabled-link-hover-color:             $gray-light !default;
 
-$nav-link-padding-lg:                       11px 24px !default;
+$nav-link-padding-lg:                       11px 15px !default;
 
 //== Tabs
 $nav-tabs-link-color:                       $nav-link-color !default;

--- a/assets/stylesheets/bootstrap/mixins/_color.scss
+++ b/assets/stylesheets/bootstrap/mixins/_color.scss
@@ -1,0 +1,8 @@
+// Color
+@mixin color-and-fill($color) {
+  color: $color;
+
+  .kamon {
+    fill: $color;
+  }
+}

--- a/demo/tatami/src/client/js/components/navs.js
+++ b/demo/tatami/src/client/js/components/navs.js
@@ -54,71 +54,75 @@ export default function Navs () {
 
       <h3>Stacked pills</h3>
       <div className='row'>
-        <ul className='nav nav-pills nav-stacked col-sm-4'>
-          <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
-          <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <div className='nav-divider' />
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <Kamon name='arrow-down-rect' />
-              <span>Forward icon</span>
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <Kamon name='trash' />
-              <span>Forward icon</span>
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <Kamon name='enter' />
-              <span>Forward icon</span>
-            </a>
-          </li>
-          <div className='nav-divider' />
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <span>Backward icon</span>
-              <Kamon name='check' />
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <span>Backward icon</span>
-              <Kamon name='locked' />
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <span>Backward icon</span>
-              <Kamon name='star' />
-            </a>
-          </li>
-          <div className='nav-divider' />
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='nav-stacked-thumbnail' />
-              <span>Square thumbnail</span>
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='img-circle nav-stacked-thumbnail' />
-              <span>Circle thumbnail</span>
-            </a>
-          </li>
-        </ul>
-        <ul className='nav nav-pills nav-stacked nav-stacked-fixed col-sm-4'>
-          <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
-          <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-        </ul>
+        <div className='col-sm-4'>
+          <ul className='nav nav-pills nav-stacked'>
+            <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+            <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <div className='nav-divider' />
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <Kamon name='arrow-down-rect' />
+                <span>Forward icon</span>
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <Kamon name='trash' />
+                <span>Forward icon</span>
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <Kamon name='enter' />
+                <span>Forward icon</span>
+              </a>
+            </li>
+            <div className='nav-divider' />
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <span>Backward icon</span>
+                <Kamon name='check' />
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <span>Backward icon</span>
+                <Kamon name='locked' />
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <span>Backward icon</span>
+                <Kamon name='star' />
+              </a>
+            </li>
+            <div className='nav-divider' />
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='nav-stacked-thumbnail' />
+                <span>Square thumbnail</span>
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='img-circle nav-stacked-thumbnail' />
+                <span>Circle thumbnail</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div className='col-sm-4'>
+          <ul className='nav nav-pills nav-stacked nav-stacked-fixed'>
+            <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+            <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          </ul>
+        </div>
       </div>
 
       <br /><br />
@@ -188,71 +192,75 @@ export default function Navs () {
 
       <h3>Stacked pills</h3>
       <div className='row'>
-        <ul className='nav nav-pills nav-stacked nav-lg col-sm-4'>
-          <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
-          <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <div className='nav-divider' />
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <Kamon name='arrow-down-rect' />
-              <span>Forward icon</span>
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <Kamon name='trash' />
-              <span>Forward icon</span>
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <Kamon name='enter' />
-              <span>Forward icon</span>
-            </a>
-          </li>
-          <div className='nav-divider' />
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <span>Backward icon</span>
-              <Kamon name='check' />
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <span>Backward icon</span>
-              <Kamon name='locked' />
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <span>Backward icon</span>
-              <Kamon name='star' />
-            </a>
-          </li>
-          <div className='nav-divider' />
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='nav-stacked-thumbnail'/>
-              <span>Square thumbnail</span>
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='img-circle nav-stacked-thumbnail' />
-              <span>Circle thumbnail</span>
-            </a>
-          </li>
-        </ul>
-        <ul className='nav nav-pills nav-stacked nav-stacked-fixed nav-lg col-sm-4'>
-          <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
-          <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-          <li role='presentation'><a href='javascript:;'>Messages</a></li>
-        </ul>
+        <div className='col-sm-4'>
+          <ul className='nav nav-pills nav-stacked nav-lg'>
+            <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+            <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <div className='nav-divider' />
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <Kamon name='arrow-down-rect' />
+                <span>Forward icon</span>
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <Kamon name='trash' />
+                <span>Forward icon</span>
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <Kamon name='enter' />
+                <span>Forward icon</span>
+              </a>
+            </li>
+            <div className='nav-divider' />
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <span>Backward icon</span>
+                <Kamon name='check' />
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <span>Backward icon</span>
+                <Kamon name='locked' />
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <span>Backward icon</span>
+                <Kamon name='star' />
+              </a>
+            </li>
+            <div className='nav-divider' />
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='nav-stacked-thumbnail'/>
+                <span>Square thumbnail</span>
+              </a>
+            </li>
+            <li role='presentation'>
+              <a href='javascript:;'>
+                <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='img-circle nav-stacked-thumbnail' />
+                <span>Circle thumbnail</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div className='col-sm-4'>
+          <ul className='nav nav-pills nav-stacked nav-stacked-fixed nav-lg'>
+            <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+            <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+            <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          </ul>
+        </div>
       </div>
 
       <br /><br />

--- a/demo/tatami/src/client/js/components/navs.js
+++ b/demo/tatami/src/client/js/components/navs.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Kamon from './kamon'
 
 export default function Navs () {
   return (
@@ -56,6 +57,30 @@ export default function Navs () {
         <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
         <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
         <li role='presentation'><a href='javascript:;'>Messages</a></li>
+        <li role='presentation'>
+          <a href='javascript:;'>
+            <Kamon name='arro-down-rect' />
+            <span>Forward icon</span>
+          </a>
+        </li>
+        <li role='presentation'>
+          <a href='javascript:;'>
+            <span>Backward icon</span>
+            <Kamon name='check' />
+          </a>
+        </li>
+        <li role='presentation'>
+          <a href='javascript:;'>
+            <img src='' className='nav-stacked-thumbnaiil' />
+            <span>Square thumbnail</span>
+          </a>
+        </li>
+        <li role='presentation'>
+          <a href='javascript:;'>
+            <img src='' className='img-circle nav-stacked-thumbnail' />
+            <span>Circle thumbnail</span>
+          </a>
+        </li>
       </ul>
 
       <h3>Stacked pills fixed</h3>

--- a/demo/tatami/src/client/js/components/navs.js
+++ b/demo/tatami/src/client/js/components/navs.js
@@ -53,42 +53,73 @@ export default function Navs () {
       <br /><br />
 
       <h3>Stacked pills</h3>
-      <ul className='nav nav-pills nav-stacked'>
-        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
-        <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
-        <li role='presentation'><a href='javascript:;'>Messages</a></li>
-        <li role='presentation'>
-          <a href='javascript:;'>
-            <Kamon name='arro-down-rect' />
-            <span>Forward icon</span>
-          </a>
-        </li>
-        <li role='presentation'>
-          <a href='javascript:;'>
-            <span>Backward icon</span>
-            <Kamon name='check' />
-          </a>
-        </li>
-        <li role='presentation'>
-          <a href='javascript:;'>
-            <img src='' className='nav-stacked-thumbnaiil' />
-            <span>Square thumbnail</span>
-          </a>
-        </li>
-        <li role='presentation'>
-          <a href='javascript:;'>
-            <img src='' className='img-circle nav-stacked-thumbnail' />
-            <span>Circle thumbnail</span>
-          </a>
-        </li>
-      </ul>
-
-      <h3>Stacked pills fixed</h3>
-      <ul className='nav nav-pills nav-stacked nav-stacked-fixed'>
-        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
-        <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
-        <li role='presentation'><a href='javascript:;'>Messages</a></li>
-      </ul>
+      <div className='row'>
+        <ul className='nav nav-pills nav-stacked col-sm-4'>
+          <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+          <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <div className='nav-divider' />
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <Kamon name='arrow-down-rect' />
+              <span>Forward icon</span>
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <Kamon name='trash' />
+              <span>Forward icon</span>
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <Kamon name='enter' />
+              <span>Forward icon</span>
+            </a>
+          </li>
+          <div className='nav-divider' />
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <span>Backward icon</span>
+              <Kamon name='check' />
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <span>Backward icon</span>
+              <Kamon name='locked' />
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <span>Backward icon</span>
+              <Kamon name='direction-right' />
+            </a>
+          </li>
+          <div className='nav-divider' />
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='nav-stacked-thumbnail' />
+              <span>Square thumbnail</span>
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='img-circle nav-stacked-thumbnail' />
+              <span>Circle thumbnail</span>
+            </a>
+          </li>
+        </ul>
+        <ul className='nav nav-pills nav-stacked nav-stacked-fixed col-sm-4'>
+          <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+          <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+        </ul>
+      </div>
 
       <br /><br />
 
@@ -156,21 +187,81 @@ export default function Navs () {
       <br /><br />
 
       <h3>Stacked pills</h3>
-      <ul className='nav nav-pills nav-stacked nav-lg'>
-        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
-        <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
-        <li role='presentation'><a href='javascript:;'>Messages</a></li>
-      </ul>
-
-      <h3>Stacked pills fixed</h3>
-      <ul className='nav nav-pills nav-stacked nav-stacked-fixed nav-lg'>
-        <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
-        <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
-        <li role='presentation'><a href='javascript:;'>Messages</a></li>
-      </ul>
+      <div className='row'>
+        <ul className='nav nav-pills nav-stacked nav-lg col-sm-4'>
+          <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+          <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <div className='nav-divider' />
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <Kamon name='arrow-down-rect' />
+              <span>Forward icon</span>
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <Kamon name='trash' />
+              <span>Forward icon</span>
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <Kamon name='enter' />
+              <span>Forward icon</span>
+            </a>
+          </li>
+          <div className='nav-divider' />
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <span>Backward icon</span>
+              <Kamon name='check' />
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <span>Backward icon</span>
+              <Kamon name='locked' />
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <span>Backward icon</span>
+              <Kamon name='direction-right' />
+            </a>
+          </li>
+          <div className='nav-divider' />
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='nav-stacked-thumbnail'/>
+              <span>Square thumbnail</span>
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='img-circle nav-stacked-thumbnail' />
+              <span>Circle thumbnail</span>
+            </a>
+          </li>
+          <li role='presentation'>
+            <a href='javascript:;'>
+              <span>Backward icon</span>
+              <Kamon name='direction-right' />
+            </a>
+          </li>
+        </ul>
+        <ul className='nav nav-pills nav-stacked nav-stacked-fixed nav-lg col-sm-4'>
+          <li role='presentation' className='active'><a href='javascript:;'>Home</a></li>
+          <li role='presentation' className='disabled'><a href='javascript:;'>Profile</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+          <li role='presentation'><a href='javascript:;'>Messages</a></li>
+        </ul>
+      </div>
 
       <br /><br />
-
       <h3>Justified</h3>
       <ul className='nav nav-tabs nav-justified nav-lg' role='tablist'>
         <li role='presentation' className='active'><a href='#home' aria-controls='home' role='tab' data-toggle='tab'>Home</a></li>

--- a/demo/tatami/src/client/js/components/navs.js
+++ b/demo/tatami/src/client/js/components/navs.js
@@ -95,7 +95,7 @@ export default function Navs () {
           <li role='presentation'>
             <a href='javascript:;'>
               <span>Backward icon</span>
-              <Kamon name='direction-right' />
+              <Kamon name='star' />
             </a>
           </li>
           <div className='nav-divider' />
@@ -229,7 +229,7 @@ export default function Navs () {
           <li role='presentation'>
             <a href='javascript:;'>
               <span>Backward icon</span>
-              <Kamon name='direction-right' />
+              <Kamon name='star' />
             </a>
           </li>
           <div className='nav-divider' />
@@ -243,12 +243,6 @@ export default function Navs () {
             <a href='javascript:;'>
               <img src='https://i.gyazo.com/4666f59908357a9ddf38d17cd36ad295.jpg' className='img-circle nav-stacked-thumbnail' />
               <span>Circle thumbnail</span>
-            </a>
-          </li>
-          <li role='presentation'>
-            <a href='javascript:;'>
-              <span>Backward icon</span>
-              <Kamon name='direction-right' />
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## 概要
navsでアイコンとサムネールを使えるようにしました。現状のプロダクトではtabやpillでアイコンやサムネールの利用例がないのでstackedに限定して更新しています。

## 確認内容
- #navsで適切な表示がされていることを確認
（サンプルが見づらいかもですが、この辺り後でまとめて整理したいです）

## スクリーンショット

デフォルトサイズ
[![Screenshot from Gyazo](https://gyazo.com/7a32fb669eebbaa529da4b138cbc5859/raw)](https://gyazo.com/7a32fb669eebbaa529da4b138cbc5859)

Largeサイズ
[![Screenshot from Gyazo](https://gyazo.com/c0ffbdd6afe49df95fca0b43e3d0f061/raw)](https://gyazo.com/c0ffbdd6afe49df95fca0b43e3d0f061)
