### PR TITLE
Dropdown hoverをグレーに戻す

### DIFF
--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -88,12 +88,18 @@
 
 // Active/Hover/Focus state
 .dropdown-menu > li > a {
-  &:active,
-  [data-hover-visible] &:hover,
-  [data-focus-visible] &:focus {
+  [data-hover-visible] &:hover {
     text-decoration: none;
     color: $dropdown-link-hover-color;
     background-color: $dropdown-link-hover-bg;
+  }
+
+  [data-focus-visible] &:focus,
+  &:active,
+  [data-hover-visible] &:hover:active {
+    text-decoration: none;
+    color: $dropdown-link-hover-color;
+    background-color: darken($btn-default-bg, 10%);
   }
 
   [data-focus-visible] &:focus {
@@ -120,43 +126,6 @@
     background-color: $dropdown-link-active-bg;
   }
 }
-
-// Selected state
-.dropdown-menu > .selected > a {
-  color: $brand-primary;
-}
-
-// Light gray hover style
-.dropdown-menu-light-hover-style {
-  > li > a {
-    // hover / focus
-    [data-hover-visible] &:hover,
-    [data-focus-visible] &:focus {
-      text-decoration: none;
-      color: $dropdown-link-color;
-      background-color: darken($btn-default-bg, 5%);
-    }
-
-    // hover / focus
-    &:active {
-      &,
-      [data-hover-visible] &:hover,
-      [data-focus-visible] &:focus {
-
-        text-decoration: none;
-        color: $dropdown-link-color;
-        background-color: darken($btn-default-bg, 10%);
-
-      }
-    }
-  }
-
-  > .selected > a {
-    color: $brand-primary !important;
-  }
-}
-
-
 
 // Disabled state
 //

--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -88,22 +88,20 @@
 
 // Active/Hover/Focus state
 .dropdown-menu > li > a {
-  [data-hover-visible] &:hover {
+  [data-hover-visible] &:hover,
+  [data-focus-visible] &:focus {
     text-decoration: none;
     color: $dropdown-link-hover-color;
     background-color: $dropdown-link-hover-bg;
   }
 
-  [data-focus-visible] &:focus,
-  &:active,
-  [data-hover-visible] &:hover:active {
-    text-decoration: none;
-    color: $dropdown-link-hover-color;
-    background-color: darken($btn-default-bg, 10%);
-  }
-
-  [data-focus-visible] &:focus {
-    box-shadow: none;
+  &:active {
+    &,
+    [data-hover-visible] &:hover {
+      text-decoration: none;
+      color: $dropdown-link-hover-color;
+      background-color: darken($btn-default-bg, 10%);
+    }
   }
 }
 

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -254,9 +254,9 @@ $dropdown-divider-bg:            #e5e5e5 !default;
 //** Dropdown link text color.
 $dropdown-link-color:            $text-color !default;
 //** Hover color for dropdown links.
-$dropdown-link-hover-color:      $component-active-color !default;
+$dropdown-link-hover-color:      $text-color !default;
 //** Hover background for dropdown links.
-$dropdown-link-hover-bg:         $component-active-bg !default;
+$dropdown-link-hover-bg:         darken($btn-default-bg, 5%) !default;
 
 //** Active dropdown menu item text color.
 $dropdown-link-active-color:     $component-active-color !default;

--- a/demo/tatami/src/client/js/components/dropdowns.js
+++ b/demo/tatami/src/client/js/components/dropdowns.js
@@ -14,7 +14,6 @@ export default function Dropdowns () {
           <li><a href='javascript:;'>Save</a></li>
           <li><a href='javascript:;'>Open in Chrome</a></li>
           <li role='separator' className='divider' />
-          <li className='selected'><a href='javascript:;'>Selected link</a></li>
           <li className='disabled'><a href='javascript:;'>Disabled link</a></li>
         </ul>
       </div>
@@ -32,7 +31,6 @@ export default function Dropdowns () {
           <li><a href='javascript:;'>Save</a></li>
           <li><a href='javascript:;'>Open in Chrome</a></li>
           <li role='separator' className='divider' />
-          <li className='selected'><a href='javascript:;'>Selected link</a></li>
           <li className='disabled'><a href='javascript:;'>Disabled link</a></li>
         </ul>
       </div>
@@ -80,27 +78,7 @@ export default function Dropdowns () {
           <li><a href='javascript:;'>Save</a></li>
           <li><a href='javascript:;'>Open in Chrome</a></li>
           <li><a href='javascript:;'>Print</a></li>
-          <li className='selected'><a href='javascript:;'>Share</a></li>
-          <li className='dropdown-header'>Header</li>
-          <li><a href='javascript:;'>Download</a></li>
-          <li><a href='javascript:;'>Delete</a></li>
-        </ul>
-      </div>
-
-      <h3>Light hover style</h3>
-
-      <div className='dropdown'>
-        <button className='btn btn-clear btn-lg dropdown-toggle' type='button' id='dropdownMenu2'
-          tabIndex='0'
-          data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
-          Dropdown <span className='caret' />
-        </button>
-        <ul className='dropdown-menu dropdown-menu-lg dropdown-menu-light-hover-style' aria-labelledby='dropdownMenu2'>
-          <li><a href='javascript:;'>New</a></li>
-          <li><a href='javascript:;'>Save</a></li>
-          <li><a href='javascript:;'>Open in Chrome</a></li>
-          <li><a href='javascript:;'>Print</a></li>
-          <li className='selected'><a href='javascript:;'>Share</a></li>
+          <li><a href='javascript:;'>Share</a></li>
           <li className='dropdown-header'>Header</li>
           <li><a href='javascript:;'>Download</a></li>
           <li><a href='javascript:;'>Delete</a></li>


### PR DESCRIPTION
濃い青にすると、scrapboxの次のメニューと相性が悪そうなので一旦戻します。

btn-cleanと一致させています。現行よりはすこし濃くなっています。
また、focusでactive状態と同じ濃さになるようにしたので、キーボードでフォーカス移動したときに分かりやすくはなっています。

[![Screenshot from Gyazo](https://gyazo.com/d14ff410fa2eaac17b7f01bd175cbc62/raw)](https://gyazo.com/d14ff410fa2eaac17b7f01bd175cbc62)