### PR TITLE
Dropdownのactive colorを設定

### DIFF
--- a/assets/stylesheets/bootstrap/_dropdowns.scss
+++ b/assets/stylesheets/bootstrap/_dropdowns.scss
@@ -124,44 +124,9 @@
   &:active,
   [data-hover-visible] &:hover,
   [data-focus-visible] &:focus {
-    color: $dropdown-link-active-color;
-    text-decoration: none;
-    outline: 0;
-    background-color: $dropdown-link-active-bg;
+    color: $dropdown-link-active-color !important;
   }
 }
-
-// Light gray hover style
-.dropdown-menu-light-hover-style {
-  > li > a {
-    // hover / focus
-    [data-hover-visible] &:hover,
-    [data-focus-visible] &:focus {
-      text-decoration: none;
-      color: $dropdown-link-color;
-      background-color: darken($btn-default-bg, 5%);
-    }
-
-    // hover / focus
-    &:active {
-      &,
-      [data-hover-visible] &:hover,
-      [data-focus-visible] &:focus {
-
-        text-decoration: none;
-        color: $dropdown-link-color;
-        background-color: darken($btn-default-bg, 10%);
-
-      }
-    }
-  }
-
-  > .selected > a {
-    color: $brand-primary !important;
-  }
-}
-
-
 
 // Disabled state
 //

--- a/assets/stylesheets/bootstrap/_variables.scss
+++ b/assets/stylesheets/bootstrap/_variables.scss
@@ -259,9 +259,9 @@ $dropdown-link-hover-color:      $text-color !default;
 $dropdown-link-hover-bg:         darken($btn-default-bg, 5%) !default;
 
 //** Active dropdown menu item text color.
-$dropdown-link-active-color:     $component-active-color !default;
+$dropdown-link-active-color:     $brand-primary !default;
 //** Active dropdown menu item background color.
-$dropdown-link-active-bg:        $component-active-bg !default;
+$dropdown-link-active-bg:        $dropdown-bg !default;
 
 //** Disabled dropdown menu item background color.
 $dropdown-link-disabled-color:   $gray-light !default;

--- a/demo/tatami/src/client/js/components/dropdowns.js
+++ b/demo/tatami/src/client/js/components/dropdowns.js
@@ -14,6 +14,7 @@ export default function Dropdowns () {
           <li><a href='javascript:;'>Save</a></li>
           <li><a href='javascript:;'>Open in Chrome</a></li>
           <li role='separator' className='divider' />
+          <li className='active'><a href='javascript:;'>Active link</a></li>
           <li className='disabled'><a href='javascript:;'>Disabled link</a></li>
         </ul>
       </div>
@@ -95,27 +96,6 @@ export default function Dropdowns () {
           Dropdown <span className='caret' />
         </button>
         <ul className='dropdown-menu dropdown-menu-auto-size' aria-labelledby='dropdownMenu2'>
-          <li><a href='javascript:;'>New</a></li>
-          <li><a href='javascript:;'>Save</a></li>
-          <li><a href='javascript:;'>Open in Chrome</a></li>
-          <li><a href='javascript:;'>Print</a></li>
-          <li><a href='javascript:;'>Share</a></li>
-          <li className='dropdown-header'>Header</li>
-          <li><a href='javascript:;'>Download</a></li>
-          <li><a href='javascript:;'>Delete</a></li>
-        </ul>
-      </div>
-
-      <br />
-      <h3>Light hover style</h3>
-
-      <div className='dropdown'>
-        <button className='btn btn-clear btn-lg dropdown-toggle' type='button' id='dropdownMenu2'
-          tabIndex='0'
-          data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
-          Dropdown <span className='caret' />
-        </button>
-        <ul className='dropdown-menu dropdown-menu-lg dropdown-menu-light-hover-style' aria-labelledby='dropdownMenu2'>
           <li><a href='javascript:;'>New</a></li>
           <li><a href='javascript:;'>Save</a></li>
           <li><a href='javascript:;'>Open in Chrome</a></li>


### PR DESCRIPTION
Dropdown menuのactive状態は、やはりときどき利用するということがわかったので真面目に設計する。
注: これは :active とは異なり、「選択されている」という意味あいのやつです。Bootstrapに存在するので必要な場面がある。

デフォルトでは、背景色がbrand-primaryで、文字が白色になるが、文字をprimary colorにして背景色は普通の状態にあわせることにする。

Scrapboxの並べ替えや、設定タブの折りたたみなどで利用している

[![Screenshot from Gyazo](https://gyazo.com/2ae81a5ebeb202385229e6d11e8e93ec/raw)](https://gyazo.com/2ae81a5ebeb202385229e6d11e8e93ec)