### PR TITLE
npm publish直前にtestを実行する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.5.0
+      - image: circleci/node:10.15.3
 
     working_directory: ~/app
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "sass-lint": "sass-lint -v --no-exit",
     "sass-lint-fix": "sass-lint-auto-fix",
-    "test": "npm run sass-lint && sh test/*.sh"
+    "test": "npm run sass-lint && sh test/*.sh",
+    "prepublishOnly": "npm test"
   },
   "files": [
     "assets",


### PR DESCRIPTION
publish直前にnpm testを実行する様にしました。
sass-lintと、 `test/node_sass_compile_test.sh` 等が実行されます。
文法エラーがあるsassや、ビルドできないsassファイルがあれば、publish直前に止まる様になります。

## 動作確認方法

    $ npm publish --dry-run

これでtestが走ってからnpm publish準備に入ればok（publishまでは実行されません）