### PR TITLE
dropdown dividerにmin-heightを設定

### DIFF
--- a/assets/stylesheets/bootstrap/mixins/_nav-divider.scss
+++ b/assets/stylesheets/bootstrap/mixins/_nav-divider.scss
@@ -4,6 +4,7 @@
 
 @mixin nav-divider($color: #e5e5e5) {
   height: 1px;
+  min-height: 1px;
   margin: (($line-height-computed / 2) - 1) 0;
   overflow: hidden;
   background-color: $color;


### PR DESCRIPTION
https://github.com/nota/scrapbox/pull/4739#discussion_r571022935 より

dropdown listのdividerにmin-heightが設定されていない為、 `overflow: auto` の中で優先的に折りたたまれて消えてしまう。
dividerは消えない方がよい。